### PR TITLE
fix(media): correct fetching and upload methods for multimedia

### DIFF
--- a/src/Components/ImageUploadTest.jsx
+++ b/src/Components/ImageUploadTest.jsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import axios from 'axios';
 import { uploadMedia, testMediaFetch, getMediaUrl } from '../Services/MediaService';
 import { testApiConnectivity, testMinimalFileUpload } from '../Services/ApiTest';
 

--- a/src/Components/ImageUploadTest.jsx
+++ b/src/Components/ImageUploadTest.jsx
@@ -11,6 +11,7 @@ export default function ImageUploadTest() {
   const [minimalUploadResult, setMinimalUploadResult] = useState(null);
   const [mediaFetchResult, setMediaFetchResult] = useState(null);
   const [fetchedImageUrl, setFetchedImageUrl] = useState('');
+  const [fetchedMediaType, setFetchedMediaType] = useState();
 
   const handleFileChange = (e) => {
     setFile(e.target.files[0]);
@@ -132,8 +133,10 @@ export default function ImageUploadTest() {
                   setMediaFetchResult(result);
                   if (result.success) {
                     setFetchedImageUrl(getMediaUrl(entityType, entityId || '1'));
+                    setFetchedMediaType(result.contentType); // NEW: set media type
                   } else {
                     setFetchedImageUrl('');
+                    setFetchedMediaType('');
                   }
                 }}
               >
@@ -182,17 +185,32 @@ export default function ImageUploadTest() {
                 
                 {fetchedImageUrl && (
                   <div className="mt-3">
-                    <h6>Fetched Image:</h6>
-                    <img 
-                      src={fetchedImageUrl} 
-                      alt="Fetched media" 
-                      className="img-thumbnail" 
-                      style={{ maxWidth: '200px', maxHeight: '200px' }}
-                      onError={(e) => {
-                        e.target.onerror = null;
-                        e.target.src = 'https://via.placeholder.com/200?text=Error+Loading+Image';
-                      }}
-                    />
+                    <h6>Fetched Media:</h6>
+                    {fetchedMediaType.startsWith('image/') ? (
+                        <img
+                            src={fetchedImageUrl}
+                            alt="Fetched media"
+                            className="img-thumbnail"
+                            style={{ maxWidth: '200px', maxHeight: '200px' }}
+                            onError={(e) => {
+                              e.target.onerror = null;
+                              e.target.src = 'https://via.placeholder.com/200?text=Error+Loading+Image';
+                            }}
+                        />
+                    ) : fetchedMediaType.startsWith('video/') ? (
+                        <video
+                            controls
+                            src={fetchedImageUrl}
+                            style={{ maxWidth: '300px', maxHeight: '300px' }}
+                            onError={(e) => {
+                              console.error('Video failed to load:', e);
+                            }}
+                        >
+                          Your browser does not support the video tag.
+                        </video>
+                    ) : (
+                        <div className="alert alert-warning">Unsupported media type: {fetchedMediaType}</div>
+                    )}
                   </div>
                 )}
               </div>

--- a/src/Components/RecipeForm.jsx
+++ b/src/Components/RecipeForm.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { getRecipeById, createRecipe, updateRecipe } from '../Services/RecipeService';
 import { getAllIngredients } from '../Services/IngredientService';
-import { getAllUnits } from '../Services/unitOfMeasureService';
+import { getAllUnits } from '../Services/UnitOfMeasureService';
 
 export default function RecipeForm() {
   const { id } = useParams();

--- a/src/Components/UnitOfMeasureForm.jsx
+++ b/src/Components/UnitOfMeasureForm.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { createUnit, getUnitById, updateUnit } from '../Services/unitOfMeasureService';
+import { createUnit, getUnitById, updateUnit } from '../Services/UnitOfMeasureService';
 import { getAllIngredients } from '../Services/IngredientService';
 
 export default function UnitOfMeasureForm() {

--- a/src/Components/UnitOfMeasureList.jsx
+++ b/src/Components/UnitOfMeasureList.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { getAllUnits, deleteUnit } from '../Services/unitOfMeasureService';
+import { getAllUnits, deleteUnit } from '../Services/UnitOfMeasureService';
 import { Link } from 'react-router-dom';
 import './UnitOfMeasureList.css';
 

--- a/src/Services/MediaService.js
+++ b/src/Services/MediaService.js
@@ -119,7 +119,8 @@ export const uploadMedia = async (entityType, entityId, file) => {
  * @returns {string} - The URL to stream the media
  */
 export const getMediaUrl = (entityType, entityId) => {
-  return `${API_URL}/stream/${entityType}/${entityId}`;
+  const mappedEntityType = ENTITY_TYPE_MAPPING[entityType] || entityType;
+  return `${API_URL}/stream/${mappedEntityType}/${entityId}`;
 };
 
 /**
@@ -130,8 +131,7 @@ export const getMediaUrl = (entityType, entityId) => {
  */
 export const testMediaFetch = async (entityType, entityId) => {
   try {
-    const mappedEntityType = ENTITY_TYPE_MAPPING[entityType] || entityType;
-    const url = getMediaUrl(mappedEntityType, entityId);
+    const url = getMediaUrl(entityType, entityId);
     console.log(`Testing media fetch from URL: ${url}`);
     
     // Test fetch with Axios

--- a/src/Services/MediaService.js
+++ b/src/Services/MediaService.js
@@ -4,12 +4,12 @@ const API_URL = 'http://localhost:8080/api/media';
 
 // Map frontend entity types to backend entity types if necessary
 const ENTITY_TYPE_MAPPING = {
-  'exercise': 'exercise',
-  'workout-plan': 'workoutPlan', // Possible backend naming (camelCase)
-  'muscle-group': 'muscleGroup', // Possible backend naming (camelCase)
-  'plan-type': 'planType',       // Possible backend naming (camelCase)
-  'recipe': 'recipe',
-  'dish': 'dish'
+  'exercise': 'Exercise',
+  'workout-plan': 'WorkoutPlan', // Possible backend naming (camelCase)
+  'muscle-group': 'MuscleGroup', // Possible backend naming (camelCase)
+  'plan-type': 'PlanType',       // Possible backend naming (camelCase)
+  'recipe': 'Recipe',
+  'dish': 'Dish'
 };
 
 /**
@@ -130,7 +130,8 @@ export const getMediaUrl = (entityType, entityId) => {
  */
 export const testMediaFetch = async (entityType, entityId) => {
   try {
-    const url = getMediaUrl(entityType, entityId);
+    const mappedEntityType = ENTITY_TYPE_MAPPING[entityType] || entityType;
+    const url = getMediaUrl(mappedEntityType, entityId);
     console.log(`Testing media fetch from URL: ${url}`);
     
     // Test fetch with Axios

--- a/src/Services/MediaService.js
+++ b/src/Services/MediaService.js
@@ -38,7 +38,7 @@ export const uploadMedia = async (entityType, entityId, file) => {
   console.log('FormData created with file:', file.name, 'type:', file.type, 'size:', file.size);
   
   // Test direct API URL (confirmed working with curl test)
-  const directUrl = `${API_URL}/upload/${entityType}/${entityId}`;
+  const directUrl = `${API_URL}/upload/${mappedEntityType}/${entityId}`;
   console.log(`Trying direct upload URL: ${directUrl}`);
   
   try {


### PR DESCRIPTION
This pull request introduces several changes to enhance media handling in the `ImageUploadTest` component, correct naming conventions in service imports, and improve entity type mapping in the `MediaService`. The most significant updates include supporting multiple media types (images and videos), fixing inconsistent naming in service imports, and ensuring entity type mapping is applied consistently across media-related functions.

### Media Handling Enhancements:
* [`src/Components/ImageUploadTest.jsx`](diffhunk://#diff-1a91cf95970210462be029bcfd20a7cf2994884704289ea5c9ba87b6f8199a9fR14): Added support for displaying video files alongside images by introducing a conditional check for media type (`fetchedMediaType`). Unsupported media types now display a warning message. [[1]](diffhunk://#diff-1a91cf95970210462be029bcfd20a7cf2994884704289ea5c9ba87b6f8199a9fR14) [[2]](diffhunk://#diff-1a91cf95970210462be029bcfd20a7cf2994884704289ea5c9ba87b6f8199a9fR136-R139) [[3]](diffhunk://#diff-1a91cf95970210462be029bcfd20a7cf2994884704289ea5c9ba87b6f8199a9fL186-R189) [[4]](diffhunk://#diff-1a91cf95970210462be029bcfd20a7cf2994884704289ea5c9ba87b6f8199a9fR200-R213)



### Entity Type Mapping Improvements:
* [`src/Services/MediaService.js`](diffhunk://#diff-05e14bb0cfe525625c20886e6b177585ce751f70ee4615d7841604f138764820L7-R12): Updated `ENTITY_TYPE_MAPPING` to use PascalCase for backend entity types and applied this mapping in `uploadMedia` and `getMediaUrl` functions to ensure consistent API requests. [[1]](diffhunk://#diff-05e14bb0cfe525625c20886e6b177585ce751f70ee4615d7841604f138764820L7-R12) [[2]](diffhunk://#diff-05e14bb0cfe525625c20886e6b177585ce751f70ee4615d7841604f138764820L41-R41) [[3]](diffhunk://#diff-05e14bb0cfe525625c20886e6b177585ce751f70ee4615d7841604f138764820L122-R123)'

### Related Issues:
* Closes #4 