### PR TITLE
fix(AdminDashboard): fix meal plan types location and enhance category text

### DIFF
--- a/src/Pages/AdminDashboard.jsx
+++ b/src/Pages/AdminDashboard.jsx
@@ -4,7 +4,7 @@ export default function AdminDashboard() {
   return (
     <div className="admin-dashboard">
       <h2 className="dashboard-header">Panel de Administración</h2>
-      
+
       <div className="row">
         <div className="col-md-6">
           <div className="card fitai-card mb-4">
@@ -37,6 +37,10 @@ export default function AdminDashboard() {
                   <div className="icon-container"><i className="fas fa-tags"></i></div>
                   Categorías
                 </Link>
+                <Link to="/plan-types" className="list-group-item list-group-item-action">
+                  <div className="icon-container"><i className="fas fa-list-alt"></i></div>
+                  Tipos de Planes de Alimentación
+                </Link>
                 <Link to="/meal-plans" className="list-group-item list-group-item-action">
                   <div className="icon-container"><i className="fas fa-clipboard-list"></i></div>
                   Planes de Alimentación
@@ -45,7 +49,7 @@ export default function AdminDashboard() {
             </div>
           </div>
         </div>
-        
+
         <div className="col-md-6">
           <div className="card fitai-card">
             <div className="card-header">
@@ -60,10 +64,6 @@ export default function AdminDashboard() {
                 <Link to="/exercises" className="list-group-item list-group-item-action">
                   <div className="icon-container"><i className="fas fa-running"></i></div>
                   Ejercicios
-                </Link>
-                <Link to="/plan-types" className="list-group-item list-group-item-action">
-                  <div className="icon-container"><i className="fas fa-list-alt"></i></div>
-                  Tipos de Plan
                 </Link>
                 <Link to="/workout-plans" className="list-group-item list-group-item-action">
                   <div className="icon-container"><i className="fas fa-calendar-alt"></i></div>

--- a/src/Pages/AdminDashboard.jsx
+++ b/src/Pages/AdminDashboard.jsx
@@ -35,7 +35,7 @@ export default function AdminDashboard() {
                 </Link>
                 <Link to="/categories" className="list-group-item list-group-item-action">
                   <div className="icon-container"><i className="fas fa-tags"></i></div>
-                  Categorías
+                  Categorías de Platos
                 </Link>
                 <Link to="/plan-types" className="list-group-item list-group-item-action">
                   <div className="icon-container"><i className="fas fa-list-alt"></i></div>


### PR DESCRIPTION
This pull request updates the `AdminDashboard` component in `src/Pages/AdminDashboard.jsx` to improve navigation labels and reorganize links for better clarity and consistency.

Updates to navigation labels:

* Changed the label for the `/categories` link from "Categorías" to "Categorías de Platos" to provide more specific context.

Reorganization of links:

* Added a new link for `/plan-types` labeled "Tipos de Planes de Alimentación" to provide access to meal plan types.
* Removed the `/plan-types` link labeled "Tipos de Plan" from the section near the `/workout-plans` link, consolidating it with the newly added `/plan-types` link for better organization.

Related Issues:
* Closes #8 